### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,25 +6,25 @@
 # Datatypes (KEYWORD1)
 ########################################
 
-ADB922S KEYWORD1
+ADB922S	KEYWORD1
 ########################################
 # Methods and Functions (KEYWORD2)
 ########################################
-begin KEYWORD2
-connect KEYWORD2
-reconnect KEYWORD2
-sendData KEYWORD2
-sendBinary KEYWORD2
-sendDataConfirm KEYWORD2
-sendBinaryConfirm KEYWORD2
-getDownLinkData KEYWORD2
-sleep KEYWORD2
-wakeup KEYWORD2
-getHwModel KEYWORD2
-getVersion KEYWORD2
-getEUI KEYWORD2
-getMaxPayloadSize KEYWORD2
-setTxRetryCount KEYWORD2
+begin	KEYWORD2
+connect	KEYWORD2
+reconnect	KEYWORD2
+sendData	KEYWORD2
+sendBinary	KEYWORD2
+sendDataConfirm	KEYWORD2
+sendBinaryConfirm	KEYWORD2
+getDownLinkData	KEYWORD2
+sleep	KEYWORD2
+wakeup	KEYWORD2
+getHwModel	KEYWORD2
+getVersion	KEYWORD2
+getEUI	KEYWORD2
+getMaxPayloadSize	KEYWORD2
+setTxRetryCount	KEYWORD2
 ########################################
 # Constants (LITERAL1)
 ########################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords